### PR TITLE
KAS-3497 fix report efficiency and results

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.* text eol=lf
+
+# Denote all files that are truly binary and should not be modified. (bit overkill for this project, but better safe than sorry)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.pdf binary
+*.ez binary
+*.bz2 binary
+*.swp binary

--- a/queries/reports/filters.js
+++ b/queries/reports/filters.js
@@ -19,13 +19,18 @@ export function publicationDate(params) {
     ?publicationFlow
     (MIN(?publicationDate) AS ?minPublicationDate)
   WHERE {
-    ?publicationFlow a pub:Publicatieaangelegenheid ;
-      pub:doorlooptPublicatie ?publicationSubcase .
-    ?publicationActivity pub:publicatieVindtPlaatsTijdens ?publicationSubcase .
-    ?publicationActivity a pub:PublicatieActiviteit ;
-      prov:generated ?decision .
-    ?decision a eli:LegalResource;
-      eli:date_publication ?publicationDate .
+    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+      ?publicationFlow a pub:Publicatieaangelegenheid ;
+        pub:doorlooptPublicatie ?publicationSubcase .
+      ?publicationActivity pub:publicatieVindtPlaatsTijdens ?publicationSubcase .
+      ?publicationActivity a pub:PublicatieActiviteit ;
+        prov:generated ?decision .
+    }
+    VALUES ?g { <http://mu.semte.ch/graphs/organizations/kanselarij> <http://mu.semte.ch/graphs/staatsblad> }
+    GRAPH ?g {
+      ?decision a eli:LegalResource;
+        eli:date_publication ?publicationDate .
+    }
   }
 }
 
@@ -46,10 +51,12 @@ export function decisionDate(params) {
     );
 
     return `
-?publicationFlow dct:subject ?decisionActivity .
-?decisionActivity dossier:Activiteit.startdatum ?decisionDate .
-${decisionDateStart ? `FILTER (?decisionDate >= ${decisionDateStart})` : ``}
-${decisionDateEnd ? `FILTER (?decisionDate < ${decisionDateEnd})` : ``}
+GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+  ?publicationFlow dct:subject ?decisionActivity .
+  ?decisionActivity dossier:Activiteit.startdatum ?decisionDate .
+  ${decisionDateStart ? `FILTER (?decisionDate >= ${decisionDateStart})` : ``}
+  ${decisionDateEnd ? `FILTER (?decisionDate < ${decisionDateEnd})` : ``}
+}
 `;
 }
 
@@ -64,14 +71,16 @@ export function isViaCouncilOfMinisters(params) {
   SELECT DISTINCT
    ?publicationFlow
   WHERE {
-    ?publicationFlow a pub:Publicatieaangelegenheid ;
-      dossier:behandelt ?case .
-    ?case a dossier:Dossier .
-    OPTIONAL {
-      ?case dossier:doorloopt ?subcase .
-      ?subcase a dossier:Procedurestap .
+    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+      ?publicationFlow a pub:Publicatieaangelegenheid ;
+        dossier:behandelt ?case .
+      ?case a dossier:Dossier .
+      OPTIONAL {
+        ?case dossier:doorloopt ?subcase .
+        ?subcase a dossier:Procedurestap .
+      }
+      FILTER (BOUND(?subcase) = ${isViaCouncilOfMinisters ? `TRUE` : `FALSE`})
     }
-    FILTER (BOUND(?subcase) = ${isViaCouncilOfMinisters ? `TRUE` : `FALSE`})
   }
 }
 `;
@@ -88,9 +97,11 @@ export function governmentDomains(params) {
 {
   SELECT DISTINCT ?publicationFlow WHERE {
     VALUES ?governmentDomain { ${ _governmentDomains.join('\n') } }
-    ?publicationFlow dossier:behandelt ?case .
-    ?case a dossier:Dossier ;
-      ext:beleidsgebied ?governmentDomain .
+    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+      ?publicationFlow dossier:behandelt ?case .
+      ?case a dossier:Dossier ;
+        ext:beleidsgebied ?governmentDomain .
+    }
     GRAPH <http://mu.semte.ch/graphs/public> {
       ?governmentDomain a skos:Concept ;
         skos:inScheme <http://themis.vlaanderen.be/id/concept-schema/f4981a92-8639-4da4-b1e3-0e1371feaa81> .
@@ -111,7 +122,9 @@ export function regulationType(params) {
 {
   SELECT DISTINCT ?publicationFlow WHERE {
     VALUES ?regulationType { ${ _regulationTypes.join('\n') } }
-    ?publicationFlow pub:regelgevingType ?regulationType .
+    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+      ?publicationFlow pub:regelgevingType ?regulationType .
+    }
     GRAPH <http://mu.semte.ch/graphs/public> {
       ?regulationType a ext:RegelgevingType .
     }
@@ -131,8 +144,10 @@ export function mandateePersons(params) {
 {
   SELECT DISTINCT ?publicationFlow WHERE {
     VALUES ?person { ${_mandateePersons.join('\n')} }
-    ?publicationFlow a pub:Publicatieaangelegenheid ;
+    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+      ?publicationFlow a pub:Publicatieaangelegenheid ;
       ext:heeftBevoegdeVoorPublicatie ?mandatee .
+    }
     GRAPH <http://mu.semte.ch/graphs/public> {
       ?mandatee a mandaat:Mandataris ;
         mandaat:isBestuurlijkeAliasVan ?person .

--- a/queries/reports/filters.js
+++ b/queries/reports/filters.js
@@ -91,6 +91,15 @@ export function governmentDomains(params) {
     if (!governmentDomains) {
       return ``;
     }
+    // This is a temporary hack for reports with an end date before 2022-03-02, which is the first date of a publication with a normalized policy domain
+    // this fix should be removed after the poicy domains have been normalized
+    let publicationDateRange = params.filter.publicationDate;
+    if (publicationDateRange) {
+      const [publicationDateStart, publicationDateEnd] = publicationDateRange;
+      if (publicationDateEnd && publicationDateEnd < new Date('2022-03-02')) {
+        return ``;
+      }
+    }
 
     let _governmentDomains = governmentDomains.map((uri) => sparqlEscapeUri(uri));
     return `

--- a/queries/reports/groups.js
+++ b/queries/reports/groups.js
@@ -3,7 +3,7 @@ const GovernmentDomains = {
   name: 'Beleidsdomeinen',
   subselect() {
     return `
-SELECT DISTINCT
+SELECT
   ?publicationFlow
   (GROUP_CONCAT(COALESCE(?policyDomainLabelFallback, "<geen>"); SEPARATOR='/') AS ?group)
 WHERE {
@@ -40,7 +40,7 @@ const RegulationType = {
     return `
 SELECT
   ?publicationFlow
-  (?regulationTypeLabelFallback As ?group)
+  COALESCE(?regulationTypeLabel, "<geen>") as ?group
 WHERE {
   GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
     ?publicationFlow a pub:Publicatieaangelegenheid .
@@ -52,7 +52,6 @@ WHERE {
       }
     }
   }
-  BIND (IF (BOUND(?regulationTypeLabel), ?regulationTypeLabel, '<geen>') AS ?regulationTypeLabelFallback)
 }
 ORDER BY ?group
 `;
@@ -65,7 +64,7 @@ const MandateePersons = {
     return `
 SELECT
   ?publicationFlow
-  (GROUP_CONCAT(DISTINCT ?familyNameFallback, '/' ) AS ?group) # DISTINCT some mandatees and some persons have multiple entries
+  (GROUP_CONCAT(DISTINCT COALESCE(?familyName, "<geen>") as ?familyNameFallback, '/' ) AS ?group) # DISTINCT some mandatees and some persons have multiple entries
 WHERE {
   GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
     ?publicationFlow a pub:Publicatieaangelegenheid .
@@ -79,7 +78,6 @@ WHERE {
       }
     }
   }
-  BIND (IF (BOUND(?familyName), ?familyName, '<geen>') AS ?familyNameFallback)
 }
 GROUP BY ?publicationFlow
 ORDER BY ?group

--- a/queries/reports/groups.js
+++ b/queries/reports/groups.js
@@ -5,10 +5,10 @@ const GovernmentDomains = {
     return `
 SELECT DISTINCT
   ?publicationFlow
-  (GROUP_CONCAT(?policyDomainLabelFallback; SEPARATOR='/') AS ?group)
+  (GROUP_CONCAT(COALESCE(?policyDomainLabelFallback, "<geen>"); SEPARATOR='/') AS ?group)
 WHERE {
   {
-    SELECT DISTINCT ?policyDomainLabelFallback ?publicationFlow WHERE {
+    SELECT DISTINCT COALESCE(?policyDomainLabel, "<geen>") AS ?policyDomainLabelFallback ?publicationFlow WHERE {
       GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
         ?publicationFlow
           a pub:Publicatieaangelegenheid ;
@@ -25,7 +25,6 @@ WHERE {
           }
         }
       }
-      BIND (IF (BOUND(?policyDomainLabel), ?policyDomainLabel, "<geen>") AS ?policyDomainLabelFallback)
     }
   }
 }

--- a/queries/reports/index.js
+++ b/queries/reports/index.js
@@ -25,19 +25,18 @@ PREFIX adms: <http://www.w3.org/ns/adms#>
 SELECT
   (?group AS ?${group.name})
   (COUNT(DISTINCT ?publicationFlow) AS ?Aantal_publicaties)
-  (SUM(?numberOfPages) AS ?Aantal_bladzijden)
-  (SUM(?numberOfExtractsFallback) AS ?Aantal_uittreksels)
-FROM <http://mu.semte.ch/graphs/organizations/kanselarij>
-FROM NAMED <http://mu.semte.ch/graphs/public>
+  (SUM(COALESCE(?numberOfPages, 0)) AS ?Aantal_bladzijden)
+  (SUM(COALESCE(?numberOfExtracts, 1)) AS ?Aantal_uittreksels)
 WHERE {
   { ${group.subselect(params)} }
 
-  OPTIONAL { ?publicationFlow fabio:hasPageCount ?numberOfPages . }
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    OPTIONAL { ?publicationFlow fabio:hasPageCount ?numberOfPages . }
 
-  OPTIONAL { ?publicationFlow pub:aantalUittreksels ?numberOfExtracts . }
-  BIND (IF(BOUND(?numberOfExtracts), ?numberOfExtracts, 1) AS ?numberOfExtractsFallback)
-  
-  ?publicationFlow adms:status <http://themis.vlaanderen.be/id/concept/publicatie-status/2f8dc814-bd91-4bcf-a823-baf1cdc42475> . # Gepubliceerd
+    OPTIONAL { ?publicationFlow pub:aantalUittreksels ?numberOfExtracts . }
+
+    ?publicationFlow adms:status <http://themis.vlaanderen.be/id/concept/publicatie-status/2f8dc814-bd91-4bcf-a823-baf1cdc42475> . # Gepubliceerd
+  }
 
   ${Filters.publicationDate(params)}
   ${Filters.decisionDate(params)}

--- a/queries/reports/index.js
+++ b/queries/reports/index.js
@@ -21,6 +21,7 @@ PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX beleidsdomein: <http://mu.semte.ch/vocabularies/ext/publicatie/beleidsdomein#>
 
 SELECT
   (?group AS ?${group.name})


### PR DESCRIPTION
Heb vrij veel kunnen oplossen zonder een al te grote rewrite. 

Deze branch lost de problemen met de rapporten grotendeels op.

Heb ook een aantal `BIND(IF(...))` statements vervangen door `COALESCE`, wat de performantie een gigantische boost gegeven heeft. Vooral deze was een major peformance drain, die zelfs tot timeouts leidde lokaal: https://github.com/kanselarij-vlaanderen/publication-report-service/commit/5e0057b0227a51caed4624c603ebd859ae2d2199#diff-1cad1ec5880ded0bdf170ddc86300cdbf7010507687904c4b832ceca32970709L38
Rapporten genereren nu vrijwel instant na dit te vervangen.

Op de accept db krijg ik vergelijkbare resultaten met de rapporten die in bijlage van dit ticket zitten. Hier en daar verschilt er een aantal of aantal pagina’s, maar vaak ligt dit aan de volgorde van ministers en/of het verschil met aantal uittreksels. Zou dit eens moeten testen op de productie db.

Enkel bij “Publicaties per beleidsdomein” krijg ik voor 2020 momenteel nog altijd niks. Bij 2022 lijkt dit wel goed te werken, maar daar heb ik geen vergelijkingspunt. Dat komt schijnbaar omdat er aan de procedurestappen van dit jaar geen beleidsdomeinen hangen. Wellicht een migratie die niet juist gelopen is, of misschien is dit zelfs gerelateerd aan de story rond beleidsvelden? Bespreek ik best volgende week eens met Erika en Michaël.

Als we het issue rond beleidsdomeinen uitstellen tot we later die sowieso aanpakken, kan deze PR na review gemerged denk ik.
