### PR TITLE
fix: get pub-flows via and not via MR

### DIFF
--- a/queries/reports/filters.js
+++ b/queries/reports/filters.js
@@ -97,10 +97,7 @@ export function governmentDomains(params) {
   SELECT DISTINCT ?publicationFlow WHERE {
     VALUES ?governmentDomain { ${ _governmentDomains.join('\n') } }
     GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
-      ?publicationFlow dossier:behandelt ?case .
-      ?case a dossier:Dossier .
-      ?case dossier:Dossier.isNeerslagVan ?decisionmakingFlow .
-      ?decisionmakingFlow besluitvorming:beleidsveld ?governmentDomain .
+      ?publicationFlow pub:beleidsveld ?governmentDomain .
     }
     GRAPH <http://mu.semte.ch/graphs/public> {
       ?governmentDomain a skos:Concept ;

--- a/queries/reports/groups.js
+++ b/queries/reports/groups.js
@@ -10,14 +10,9 @@ WHERE {
   {
     SELECT DISTINCT COALESCE(?policyDomainLabel, "<geen>") AS ?policyDomainLabelFallback ?publicationFlow WHERE {
       GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
-        ?publicationFlow
-          a pub:Publicatieaangelegenheid ;
-          dossier:behandelt ?case.
-        ?case
-          a dossier:Dossier .
-        ?case dossier:Dossier.isNeerslagVan ?decisionmakingFlow .
+        ?publicationFlow a pub:Publicatieaangelegenheid .
         OPTIONAL {
-          ?decisionmakingFlow besluitvorming:beleidsveld ?policyDomain .
+          ?publicationFlow pub:beleidsveld ?policyDomain .
           GRAPH <http://mu.semte.ch/graphs/public> {
             ?policyDomain
               a skos:Concept ;


### PR DESCRIPTION
`PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>` was already set in `queries/reports/index.js`

Applied @tdn's comments from https://github.com/kanselarij-vlaanderen/publication-report-service/pull/7