### PR TITLE
KAS-3751 add intermediate model decisionFlow between case and subcases

### DIFF
--- a/queries/reports/filters.js
+++ b/queries/reports/filters.js
@@ -76,7 +76,8 @@ export function isViaCouncilOfMinisters(params) {
         dossier:behandelt ?case .
       ?case a dossier:Dossier .
       OPTIONAL {
-        ?case dossier:doorloopt ?subcase .
+        ?case dossier:Dossier.isNeerslagVan ?decisionFlow .
+        ?decisionFlow dossier:doorloopt ?subcase  .
         ?subcase a dossier:Procedurestap .
       }
       FILTER (BOUND(?subcase) = ${isViaCouncilOfMinisters ? `TRUE` : `FALSE`})


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3751

query needed to be update to use `decisionmaking-flow`
The filter is only used in 1 report "type regelgeving buiten MR"

results pre and post fix compared to "type regelgeving" which lists all publications
[KAS-3751-2020-results.xlsx](https://github.com/kanselarij-vlaanderen/publication-report-service/files/10122954/KAS-3751-2020-results.xlsx)
