### PR TITLE
KAS-4883 large refactor of job model, inconsistenties, config, no more sudo

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,8 +13,5 @@ module.exports = {
   ],
   rules: {
     'prettier/prettier': 'warn',
-    // quick fixes to allow mu modules
-    'node/no-extraneous-import': 'off',
-    'node/no-missing-import': 'off',
   },
 };

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM semtech/mu-javascript-template:1.6.0
+FROM semtech/mu-javascript-template:1.8.0

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ The service is triggered by the notification of the creation of a `pub:Publicati
 Example of the creation of a `pub:PublicationMetricsExportJob` in [frontend-kaleidos]
 (https://github.com/kanselarij-vlaanderen/frontend-kaleidos).
 ```javascript
-    let user = await this.currentSession.user;
-    let now = new Date();
-    let job = this.store.createRecord('publication-metrics-export-job', {
+    const user = await this.currentSession.user;
+    const now = new Date();
+    const status = 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+    const job = this.store.createRecord('publication-metrics-export-job', {
       created: now,
       generatedBy: user,
+      status,
       config: {
         name: yourReportName,
         query: {

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
-import * as Express from 'express';
-import Mu from 'mu';
+import { app, errorHandler } from 'mu';
+import bodyParser from 'body-parser';
 import * as JobRunner from './lib/job-runner.js';
 import * as DownloadJob from './lib/download-job.js';
 import * as Delta from './lib/delta.js';
@@ -11,7 +11,7 @@ import * as Delta from './lib/delta.js';
  * 3. publication-report-service comes in action:
  *    flow: (based on the file-bundling-service @see https://github.com/kanselarij-vlaanderen/file-bundling-service)
  *    1. /delta endpoint picks up notification @see file://./lib/delta.js
- *    2. JobRunner sets status to Running and runs DownloadJob @see file://./lib/job-runner.js
+ *    2. JobRunner sets status to Busy and runs DownloadJob @see file://./lib/job-runner.js
  *    3. DownloadJob runs @see file://./lib/download-job.js
  *      1. parse job parameters @see file://./job-params.js
  *      2. build report query @see file://./queries/reports/index.js
@@ -26,13 +26,15 @@ if (!process.env.TZ) {
   process.env.TZ = 'Europe/Brussels';
 }
 
-Mu.app.post('/delta', Express.json(), async function (req, res) {
+app.post('/delta', bodyParser.json(), async (req, res) => {
   res.sendStatus(202);
 
-  let deltas = req.body;
-  let newJobUris = Delta.filterInsertedJobUris(deltas);
+  const deltas = req.body;
+  const newJobUris = Delta.filterInsertedJobUris(deltas);
 
-  for (let jobUri of newJobUris) {
+  for (const jobUri of newJobUris) {
     JobRunner.run(jobUri, DownloadJob);
   }
 });
+
+app.use(errorHandler);

--- a/config.js
+++ b/config.js
@@ -11,8 +11,25 @@ export const RESOURCE_URI_BASE = `http://mu.semte.ch/services/publication-report
 export function buildResourceUri(typePlural, uuid) {
   return RESOURCE_URI_BASE + typePlural + '/' + uuid;
 }
+export const GRAPHS = {
+  KANSELARIJ: `http://mu.semte.ch/graphs/organizations/kanselarij`,
+  PUBLIC: `http://mu.semte.ch/graphs/public`,
+  STAATSBLAD: `http://mu.semte.ch/graphs/staatsblad`,
+}
 
-export const GRAPH = `http://mu.semte.ch/graphs/organizations/kanselarij`;
+export const STATUS_PUBLISHED = 'http://themis.vlaanderen.be/id/concept/publicatie-status/2f8dc814-bd91-4bcf-a823-baf1cdc42475';
+export const CONCEPT_SCHEME_GOV_DOMAIN = 'http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81';
+
+export const JOB = {
+  STATUSES: {
+    SCHEDULED: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+    BUSY: 'http://redpencil.data.gift/id/concept/JobStatus/busy',
+    SUCCESS: 'http://redpencil.data.gift/id/concept/JobStatus/success',
+    FAILED: 'http://redpencil.data.gift/id/concept/JobStatus/failed',
+  },
+  RDF_TYPE: 'http://mu.semte.ch/vocabularies/ext/publicatie/PublicationMetricsExportJob',
+  JSONAPI_JOB_TYPE: 'file-bundling-jobs',
+};
 
 export const LOG_SPARQL_QUERIES =
   process.env.LOG_SPARQL_QUERIES != undefined

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -18,7 +18,7 @@ The parameters are passed as a JSON object. The schema for this object can be fo
 An example using all filter parameters:
 Note it is not expected the service will be called this way. For the combinations of query options in use see [./report-types.md](./report-types.md))
 ```javascript
-  let jobParams = {
+  const jobParams = {
     name: 'Publicatierapport',
     query: {
       group: 'mandateePersons',

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,8 +1,0 @@
-{
-    "compilerOptions": {
-        "baseUrl": ".",
-        "paths": {
-            "mu": ["../mu"]
-        }
-    }
-}

--- a/lib/delta.js
+++ b/lib/delta.js
@@ -1,18 +1,17 @@
+import { JOB } from '../config';
+
 export function filterInsertedJobUris(deltas) {
-  let newJobUris = [];
+  const newJobUris = [];
 
-  for (let delta of deltas) {
-    let inserts = delta.inserts;
+  for (const delta of deltas) {
+    const inserts = delta.inserts;
 
-    for (let triple of inserts) {
-      /* eslint-disable prettier/prettier */
-      let isJob =
+    for (const triple of inserts) {
+      const isJob =
         triple.predicate.value === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
-        triple.object.value === 'http://mu.semte.ch/vocabularies/ext/publicatie/PublicationMetricsExportJob';
-      /* eslint-enable prettier/prettier */
-
+        triple.object.value === JOB.RDF_TYPE;
       if (isJob) {
-        let jobUri = triple.subject.value;
+        const jobUri = triple.subject.value;
         newJobUris.push(jobUri);
       }
     }

--- a/lib/download-job.js
+++ b/lib/download-job.js
@@ -6,23 +6,22 @@ import * as Queries from '../queries/index.js';
 
 /** @param {Queries.Jobs.Job} jobRecord */
 export async function run(jobRecord) {
-  let jobParams = JobParams.parse(jobRecord.config);
+  const jobParams = JobParams.parse(jobRecord.config);
 
-  let sparqlParams = jobParams.query;
-  let sparqlQuery = Queries.Reports.build(sparqlParams);
-  let csvString = await queryCsv(sparqlQuery);
+  const sparqlParams = jobParams.query;
+  const sparqlQuery = Queries.Reports.build(sparqlParams);
+  const csvString = await queryCsv(sparqlQuery);
 
-  let filename = await ReportFilename.generate(jobRecord);
-  let extension = 'csv';
+  const filename = await ReportFilename.generate(jobRecord);
+  const extension = 'csv';
   /** @see https://www.iana.org/assignments/media-types/media-types.xhtml */
-  let mimeType = 'text/csv';
-  let muFileRecord = await MuFiles.saveText(
+  const mimeType = 'text/csv';
+  const muFileRecord = await MuFiles.saveText(
     filename,
     extension,
     mimeType,
     csvString
   );
 
-  let jobResult = muFileRecord.records.user.uri;
-  return jobResult;
+  return muFileRecord.records.user.uri;
 }

--- a/lib/job-params.js
+++ b/lib/job-params.js
@@ -2,13 +2,13 @@ import Ajv from 'ajv';
 import addAjvFormats from 'ajv-formats';
 import ParameterSchema from '../parameter-schema.js';
 
-let ajv = new Ajv();
+const ajv = new Ajv();
 addAjvFormats(ajv);
-let validate = ajv.compile(ParameterSchema);
+const validate = ajv.compile(ParameterSchema);
 
 export function parse(jobParamsJSON) {
-  let jobParams = JSON.parse(jobParamsJSON);
-  let isValid = validate(jobParams);
+  const jobParams = JSON.parse(jobParamsJSON);
+  const isValid = validate(jobParams);
   if (!isValid) throw validate.errors;
   postProcessParsedJSONParams(jobParams);
   return jobParams;
@@ -21,7 +21,7 @@ export function parse(jobParamsJSON) {
  *   in order to limit type checks
  */
 function postProcessParsedJSONParams(jobParams) {
-  let filter = jobParams.query.filter || {};
+  const filter = jobParams.query.filter || {};
   filter.decisionDate = parseDateRangeParams(filter.decisionDate);
   filter.publicationDate = parseDateRangeParams(filter.publicationDate);
   filter.isViaCouncilOfMinisters = filter.isViaCouncilOfMinisters ?? undefined;

--- a/lib/job-runner.js
+++ b/lib/job-runner.js
@@ -1,59 +1,45 @@
-// eslint-disable-next-line no-unused-vars
-import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import * as Queries from '../queries';
-
-export const JobStatus = {
-  RUNNING: 'http://vocab.deri.ie/cogs#Running',
-  SUCCESS: 'http://vocab.deri.ie/cogs#Success',
-  FAIL: 'http://vocab.deri.ie/cogs#Fail',
-};
+import { JOB } from '../config';
 
 export async function run(jobUri, job) {
   let jobRecord;
   try {
-    let jobQuery = Queries.Jobs.buildGet(jobUri);
-    let result = await querySudo(jobQuery);
+    const result = await Queries.Jobs.findJob(jobUri);
     [jobRecord] = Queries.Jobs.parseGet(result);
     if (!jobRecord.reportTypeUri) {
-      console.error(
+      throw new Error(
         `Job <${jobUri}> not yet linked to a pub:Publicationrapporttype`
       );
     }
   } catch (err) {
     console.error(`Job <${jobUri}>: error`, err);
+    await handleError(err);
     return;
   }
 
   try {
     await handleStart();
-    let jobResultUri = await job.run(jobRecord);
+    const jobResultUri = await job.run(jobRecord);
     await handleSuccess(jobResultUri);
   } catch (err) {
     await handleError(err);
+   return 
   }
 
   async function handleStart() {
-    let time = new Date();
     console.info(`Job <${jobUri}>: start`);
-    let queryStart = Queries.Jobs.updateStatusToRunning(jobUri, time);
-    await updateSudo(queryStart);
+    await Queries.Jobs.updateJobStatus(jobUri, JOB.STATUSES.BUSY);
   }
 
   async function handleSuccess(jobResultUri) {
-    let time = new Date();
     console.info(`Job <${jobUri}>: success`);
-    let successQuery = Queries.Jobs.updateStatusToSuccess(
-      jobUri,
-      time,
-      jobResultUri
-    );
-    await updateSudo(successQuery);
+    await Queries.Jobs.attachResultToJob(jobUri, jobResultUri);
+    await Queries.Jobs.updateJobStatus(jobUri, JOB.STATUSES.SUCCESS);
   }
 
   async function handleError(err) {
-    let time = new Date();
-    console.error(`Job <${jobUri}>: error`, err);
-    let failQuery = Queries.Jobs.updateStatusToError(jobUri, time);
-    await updateSudo(failQuery, true);
+    console.error(`Job <${jobUri}>: error`, err?.message);
+    console.trace(err);
+    await Queries.Jobs.updateJobStatus(jobUri, JOB.STATUSES.FAILED, err?.message);
   }
 }

--- a/lib/mu-files.js
+++ b/lib/mu-files.js
@@ -1,33 +1,30 @@
-// eslint-disable-next-line no-unused-vars
-import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import Path from 'path';
 import Fs from 'fs';
-import Mu from 'mu';
 import sanitizeFilename from 'sanitize-filename';
 import * as Config from '../config.js';
 import * as Queries from '../queries/index.js';
+import { uuid } from 'mu';
 
 export async function saveText(filename, extension, mimeType, contentString) {
-  let muFileRecord = createRecord(filename, extension, mimeType);
+  const muFileRecord = createRecord(filename, extension, mimeType);
   await Fs.promises.writeFile(muFileRecord.path, contentString, 'utf-8');
   await updateRecordStats(muFileRecord);
-  let fileInsertQuery = Queries.Files.create(
+  await Queries.Files.create(
     muFileRecord.records.user,
     muFileRecord.records.storage
   );
-  await updateSudo(fileInsertQuery);
   return muFileRecord;
 }
 
 /** @typedef {ReturnType<typeof createRecord>} MuFileRecord */
 export function createRecord(userFilename, extension, mimeType) {
-  let saneUserFilename = sanitizeFilename(userFilename);
-  let userBasename = saneUserFilename + '.' + extension;
-  let userFileUuid = Mu.uuid();
-  let userFileUri = Config.buildResourceUri('files', userFileUuid);
+  const saneUserFilename = sanitizeFilename(userFilename);
+  const userBasename = saneUserFilename + '.' + extension;
+  const userFileUuid = uuid();
+  const userFileUri = Config.buildResourceUri('files', userFileUuid);
 
   /** @type {Queries.Files.FileRecord} */
-  let userFileRecord = {
+  const userFileRecord = {
     uri: userFileUri,
     uuid: userFileUuid,
     name: userBasename,
@@ -35,13 +32,13 @@ export function createRecord(userFilename, extension, mimeType) {
     format: mimeType,
   };
 
-  let storagePathBasename = userFileUuid + '.' + extension;
-  let storagePath = Path.join(Config.STORAGE_PATH, storagePathBasename);
-  let storageFileUri = `share://` + storagePathBasename;
-  let storageFileUuid = Mu.uuid();
-  let storageFilename = storageFileUuid + '.' + extension;
+  const storagePathBasename = userFileUuid + '.' + extension;
+  const storagePath = Path.join(Config.STORAGE_PATH, storagePathBasename);
+  const storageFileUri = `share://` + storagePathBasename;
+  const storageFileUuid = uuid();
+  const storageFilename = storageFileUuid + '.' + extension;
   /** @type {Queries.Files.PhysicalFileRecord} */
-  let storageFileRecord = {
+  const storageFileRecord = {
     uri: storageFileUri,
     uuid: storageFileUuid,
     name: storageFilename,
@@ -57,9 +54,9 @@ export function createRecord(userFilename, extension, mimeType) {
 
 /** @param {MuFileRecord} muFileRecord */
 export async function updateRecordStats(muFileRecord) {
-  let fileStats = await Fs.promises.stat(muFileRecord.path);
+  const fileStats = await Fs.promises.stat(muFileRecord.path);
 
-  let { user: userFileRecord, storage: storageFileRecord } =
+  const { user: userFileRecord, storage: storageFileRecord } =
     muFileRecord.records;
 
   userFileRecord.size = storageFileRecord.size = fileStats.size;

--- a/lib/query-csv.js
+++ b/lib/query-csv.js
@@ -12,8 +12,8 @@ export async function queryCsv(
   // directly call Virtuoso's /sparql endpoint:
   // - not using mu-authorization: does only support JSON results
   // - not using node-sparql-client: package does only support JSON results
-  let urlBuilder = new URL(virtuosoSparqlEndpoint);
-  let response = await fetch(urlBuilder, {
+  const urlBuilder = new URL(virtuosoSparqlEndpoint);
+  const response = await fetch(urlBuilder, {
     method: 'POST',
     headers: new Headers({
       Accept: 'text/csv',
@@ -23,10 +23,10 @@ export async function queryCsv(
   });
 
   if (!response.ok) {
-    let message = await response.text();
+    const message = await response.text();
     throw new Error(message);
   }
 
-  let csvString = await response.text();
+  const csvString = await response.text();
   return csvString;
 }

--- a/lib/report-filename.js
+++ b/lib/report-filename.js
@@ -1,24 +1,25 @@
 import moment from 'moment';
-import EmberCliStringUtils from 'ember-cli-string-utils';
-import * as Mu from 'mu';
-import * as Queries from '../queries/index.js'; /* eslint-disable-line no-unused-vars */ // typing
+import * as Queries from '../queries/index.js';
 import * as QueryUtils from '../queries/utils.js';
 
+export function dasherize(text) {
+  return text.trim().replace(/\s/g, '-');
+}
+
 async function setup() {
-  let sparql = Queries.ReportTypes.buildGet();
-  let results = await Mu.query(sparql);
-  let reportTypeRecords = QueryUtils.sparqlParseRecords(results);
+  const results = await Queries.ReportTypes.findReportType();
+  const reportTypeRecords = QueryUtils.sparqlParseRecords(results);
   return reportTypeRecords;
 }
 const reportTypeRecordsPromise = setup();
 
 /** @param {Queries.Jobs.Job} jobRecord */
 export async function generate(jobRecord) {
-  let reportNameDatePrefix = moment(jobRecord.createdTime).format(
+  const reportNameDatePrefix = moment(jobRecord.createdTime).format(
     'YYYYMMDDHHmmss'
   );
-  let reportTypeRecords = await reportTypeRecordsPromise;
-  let reportTypeRecord = reportTypeRecords.find(
+  const reportTypeRecords = await reportTypeRecordsPromise;
+  const reportTypeRecord = reportTypeRecords.find(
     (reportTypeRecord) => reportTypeRecord.uri === jobRecord.reportTypeUri
   );
   if (!reportTypeRecord) {
@@ -26,8 +27,8 @@ export async function generate(jobRecord) {
       `No filename has been configured for report type <${jobRecord.reportTypeUri}>.`
     );
   }
-  let reportNameType = EmberCliStringUtils.dasherize(reportTypeRecord.label);
+  const reportNameType = dasherize(reportTypeRecord.label.toLowerCase());
 
-  let reportFilename = `${reportNameDatePrefix}-${reportNameType}`;
+  const reportFilename = `${reportNameDatePrefix}-${reportNameType}`;
   return reportFilename;
 }

--- a/lib/report-filename.js
+++ b/lib/report-filename.js
@@ -6,19 +6,18 @@ export function dasherize(text) {
   return text.trim().replace(/\s/g, '-');
 }
 
-async function setup() {
+async function findReportTypes() {
   const results = await Queries.ReportTypes.findReportType();
   const reportTypeRecords = QueryUtils.sparqlParseRecords(results);
   return reportTypeRecords;
 }
-const reportTypeRecordsPromise = setup();
 
 /** @param {Queries.Jobs.Job} jobRecord */
 export async function generate(jobRecord) {
   const reportNameDatePrefix = moment(jobRecord.createdTime).format(
     'YYYYMMDDHHmmss'
   );
-  const reportTypeRecords = await reportTypeRecordsPromise;
+  const reportTypeRecords = await findReportTypes();
   const reportTypeRecord = reportTypeRecords.find(
     (reportTypeRecord) => reportTypeRecord.uri === jobRecord.reportTypeUri
   );

--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
     "node": "14.16.1"
   },
   "dependencies": {
-    "@lblod/mu-auth-sudo": "~0.5.1",
     "ajv": "~8.11.0",
     "ajv-formats": "~2.1.1",
-    "ember-cli-string-utils": "~1.1.0",
     "moment": "~2.29.3",
     "node-fetch": "~2.6.7",
     "sanitize-filename": "~1.6.3"

--- a/queries/files.js
+++ b/queries/files.js
@@ -1,9 +1,9 @@
-import * as Config from '../config.js';
 import {
   sparqlEscapeUri,
   sparqlEscapeString,
   sparqlEscapeInt,
   sparqlEscapeDateTime,
+  update,
 } from 'mu';
 
 /**
@@ -23,8 +23,8 @@ import {
  * @param {FileRecord} userFileRecord
  * @param {FileRecord} storageFileRecord
  */
-export function create(userFileRecord, storageFileRecord) {
-  return `
+export async function create(userFileRecord, storageFileRecord) {
+  const queryString = `
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
 PREFIX dbpedia: <http://dbpedia.org/ontology/>
@@ -32,7 +32,6 @@ PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
 INSERT DATA {
-  GRAPH ${sparqlEscapeUri(Config.GRAPH)} {
     ${sparqlEscapeUri(userFileRecord.uri)} a nfo:FileDataObject ;
         nfo:fileName ${sparqlEscapeString(userFileRecord.name)} ;
         mu:uuid ${sparqlEscapeString(userFileRecord.uuid)} ;
@@ -52,7 +51,7 @@ INSERT DATA {
         )} ;
         dct:created ${sparqlEscapeDateTime(storageFileRecord.createdTime)} ;
         dct:modified ${sparqlEscapeDateTime(storageFileRecord.createdTime)} .
-    }
   }
 `;
+  await update(queryString);
 }

--- a/queries/jobs.js
+++ b/queries/jobs.js
@@ -1,31 +1,29 @@
-/* eslint-disable prettier/prettier */
-import { sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
+import { sparqlEscapeUri, sparqlEscapeDateTime, sparqlEscapeString, query, update } from 'mu';
+import { JOB } from '../config';
 
 /**
  *
  * @param {string?} jobUri if not provided: return all jobs
  * @returns
  */
-export function buildGet(jobUri) {
-  let _jobUri = jobUri !== undefined ? sparqlEscapeUri(jobUri) : undefined;
-
-  return `
-PREFIX cogs: <http://vocab.deri.ie/cogs#>
+export function findJob(jobUri) {
+  const _jobUri = jobUri !== undefined ? sparqlEscapeUri(jobUri) : undefined;
+  const queryString = `
 PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
 
 SELECT *
 WHERE {
   ${_jobUri ? `VALUES ?jobUri { ${_jobUri} }`: ''}
 
-  ?jobUri a pub:PublicationMetricsExportJob .
+  ?jobUri a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
   ?jobUri dct:created ?createdTime .
   ?jobUri pub:exportJobConfig ?config .
   ${/* Required relationship, but relations are added by mu-cl-resources in a different INSERT command. */ ''}
   OPTIONAL { ?jobUri dct:type ?reportTypeUri . }
-  OPTIONAL { ?jobUri ext:status ?statusUri . }
+  OPTIONAL { ?jobUri adms:status ?statusUri . }
   OPTIONAL { ?jobUri prov:startedAtTime ?startTime . }
   OPTIONAL { ?jobUri prov:endedAtTime ?endTime . }
   ${/* Required relationship, but relations are added by mu-cl-resources in a different INSERT command. */ ''}
@@ -33,17 +31,19 @@ WHERE {
   OPTIONAL { ?jobUri prov:generated ?fileUri . }
 }
 `;
+
+return query(queryString);
 }
 
 /** @typedef {ReturnType<parseGet>} Job */
 export function parseGet(data) {
-  let jobRecords = data.results.bindings.map((jobResult) => {
-    let createdTime = new Date(jobResult.createdTime.value);
-    let config = jobResult.config.value;
-    let startTime = jobResult.startTime
+  const jobRecords = data.results.bindings.map((jobResult) => {
+    const createdTime = new Date(jobResult.createdTime.value);
+    const config = jobResult.config.value;
+    const startTime = jobResult.startTime
       ? new Date(jobResult.startTime.value)
       : undefined;
-    let endTime = jobResult.endTime
+    const endTime = jobResult.endTime
       ? new Date(jobResult.endTime.value)
       : undefined;
 
@@ -61,88 +61,50 @@ export function parseGet(data) {
   return jobRecords;
 }
 
-export function updateStatusToRunning(jobUri, time) {
-  let _jobUri = sparqlEscapeUri(jobUri);
-
-  return `
-  PREFIX cogs: <http://vocab.deri.ie/cogs#>
-  PREFIX dct: <http://purl.org/dc/terms/>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+export async function attachResultToJob(job, result) {
+  const queryString = `
   PREFIX prov: <http://www.w3.org/ns/prov#>
-  PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
 
   INSERT {
-    GRAPH ?g {
-      ${_jobUri} ext:status cogs:Running .
-      ${_jobUri} prov:startedAtTime ${sparqlEscapeDateTime(time)} .
-    }
+      ${sparqlEscapeUri(job)} prov:generated ${sparqlEscapeUri(result)} .
   }
   WHERE {
-    GRAPH ?g {
-      ${_jobUri} a pub:PublicationMetricsExportJob .
-    }
-  }
-`;
+      ${sparqlEscapeUri(job)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
+  }`;
+  await update(queryString);
+  return job;
 }
 
-export function updateStatusToSuccess(jobUri, time, jobResultUri) {
-  let _jobUri = sparqlEscapeUri(jobUri);
+export async function updateJobStatus(uri, status, errorMessage) {
+  const time = new Date();
+  let timePred;
+  if (status === JOB.STATUSES.SUCCESS || status === JOB.STATUSES.FAILED) { // final statusses
+    timePred = 'http://www.w3.org/ns/prov#endedAtTime';
+  } else {
+    timePred = 'http://www.w3.org/ns/prov#startedAtTime';
+  }
+  const escapedUri = sparqlEscapeUri(uri);
+  const queryString = `
+  PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX schema: <http://schema.org/>
 
-  return `
-PREFIX cogs: <http://vocab.deri.ie/cogs#>
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
-
-DELETE {
-  GRAPH ?g {
-    ${_jobUri} ext:status cogs:Running .
+  DELETE {
+      ${escapedUri} adms:status ?status ;
+          ${sparqlEscapeUri(timePred)} ?time .
   }
-}
-INSERT {
-  GRAPH ?g {
-    ${_jobUri} ext:status cogs:Success .
-    ${_jobUri} prov:endedAtTime ${sparqlEscapeDateTime(time)} .
-    ${_jobUri} prov:generated ${sparqlEscapeUri(jobResultUri)} .
+  INSERT {
+      ${escapedUri} adms:status ${sparqlEscapeUri(status)} ;
+          ${
+            errorMessage
+              ? `schema:error ${sparqlEscapeString(errorMessage)} ;`
+              : ''
+          }
+          ${sparqlEscapeUri(timePred)} ${sparqlEscapeDateTime(time)} .
   }
-}
-WHERE {
-  GRAPH ?g {
-    ${_jobUri} a pub:PublicationMetricsExportJob .
-  }
-}
-`;
-}
-
-export function updateStatusToError(jobUri, time) {
-  let _jobUri = sparqlEscapeUri(jobUri);
-
-  return `
-PREFIX cogs: <http://vocab.deri.ie/cogs#>
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
-
-DELETE {
-  GRAPH ?g {
-    ${_jobUri} ext:status ?status .
-    ${_jobUri} prov:endedAtTime ?time .
-  }
-}
-INSERT {
-  GRAPH ?g {
-    ${_jobUri} ext:status cogs:Fail .
-    ${_jobUri} prov:endedAtTime ${sparqlEscapeDateTime(time)} .
-  }
-}
-WHERE {
-  GRAPH ?g {
-    ${_jobUri} a pub:PublicationMetricsExportJob .
-    OPTIONAL { ${_jobUri} ext:status ?status . }
-    OPTIONAL { ${_jobUri} prov:endedAtTime ?time . }
-  }
-}
-`;
+  WHERE {
+      ${escapedUri} a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
+      OPTIONAL { ${escapedUri} adms:status ?status }
+      OPTIONAL { ${escapedUri} ${sparqlEscapeUri(timePred)} ?time }
+  }`;
+  await update(queryString);
 }

--- a/queries/jobs.js
+++ b/queries/jobs.js
@@ -6,7 +6,7 @@ import { JOB } from '../config';
  * @param {string?} jobUri if not provided: return all jobs
  * @returns
  */
-export function findJob(jobUri) {
+export async function findJob(jobUri) {
   const _jobUri = jobUri !== undefined ? sparqlEscapeUri(jobUri) : undefined;
   const queryString = `
 PREFIX dct: <http://purl.org/dc/terms/>
@@ -32,7 +32,7 @@ WHERE {
 }
 `;
 
-return query(queryString);
+return await query(queryString);
 }
 
 /** @typedef {ReturnType<parseGet>} Job */

--- a/queries/report-types.js
+++ b/queries/report-types.js
@@ -1,10 +1,10 @@
-import * as Mu from 'mu';
+import { query, sparqlEscapeUri} from 'mu';
 
-export function buildGet(reportTypeUri) {
-  let _reportTypeUri =
-    reportTypeUri !== undefined ? Mu.sparqlEscapeUri(reportTypeUri) : undefined;
+export async function findReportType(reportTypeUri) {
+  const _reportTypeUri =
+    reportTypeUri !== undefined ? sparqlEscapeUri(reportTypeUri) : undefined;
 
-  return `
+  const queryString = `
 PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -18,4 +18,5 @@ WHERE {
   ?uri skos:prefLabel ?label .
 }
 `;
+  return await query(queryString);
 }

--- a/queries/reports/filters.js
+++ b/queries/reports/filters.js
@@ -1,16 +1,16 @@
-/* eslint-disable prettier/prettier */
 // fragments included in SPARQL query built in index.js
-import { sparqlEscapeDate, sparqlEscapeUri } from 'mu'; // eslint-disable-line
+import { sparqlEscapeUri } from 'mu';
 import { sparqlEscapeDateLocal } from '../utils.js';
+import { GRAPHS, CONCEPT_SCHEME_GOV_DOMAIN } from '../../config.js';
 
 export function publicationDate(params) {
-    let publicationDateRange = params.filter.publicationDate;
-    let hasFilter = publicationDateRange?.some((date) => date);
+    const publicationDateRange = params.filter.publicationDate;
+    const hasFilter = publicationDateRange?.some((date) => date);
     if (!hasFilter) {
       return ``;
     }
 
-    let [publicationDateStart, publicationDateEnd] = publicationDateRange.map(
+    const [publicationDateStart, publicationDateEnd] = publicationDateRange.map(
       (date) => (date ? sparqlEscapeDateLocal(date) : undefined)
     );
     return `
@@ -19,14 +19,14 @@ export function publicationDate(params) {
     ?publicationFlow
     (MIN(?publicationDate) AS ?minPublicationDate)
   WHERE {
-    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
       ?publicationFlow a pub:Publicatieaangelegenheid ;
         pub:doorlooptPublicatie ?publicationSubcase .
       ?publicationActivity pub:publicatieVindtPlaatsTijdens ?publicationSubcase .
       ?publicationActivity a pub:PublicatieActiviteit ;
         prov:generated ?decision .
     }
-    VALUES ?g { <http://mu.semte.ch/graphs/organizations/kanselarij> <http://mu.semte.ch/graphs/staatsblad> }
+    VALUES ?g { ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} ${sparqlEscapeUri(GRAPHS.STAATSBLAD)} }
     GRAPH ?g {
       ?decision a eli:LegalResource;
         eli:date_publication ?publicationDate .
@@ -40,18 +40,18 @@ ${publicationDateEnd ? `FILTER (?minPublicationDate < ${publicationDateEnd})` : 
 }
 
 export function decisionDate(params) {
-    let decisionDateRange = params.filter.decisionDate;
-    let hasFilter = decisionDateRange?.some((date) => date);
+    const decisionDateRange = params.filter.decisionDate;
+    const hasFilter = decisionDateRange?.some((date) => date);
     if (!hasFilter) {
       return ``;
     }
 
-    let [decisionDateStart, decisionDateEnd] = decisionDateRange.map((date) =>
+    const [decisionDateStart, decisionDateEnd] = decisionDateRange.map((date) =>
       date ? sparqlEscapeDateLocal(date) : undefined
     );
 
     return `
-GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
   ?publicationFlow dct:subject ?decisionActivity .
   ?decisionActivity dossier:Activiteit.startdatum ?decisionDate .
   ${decisionDateStart ? `FILTER (?decisionDate >= ${decisionDateStart})` : ``}
@@ -61,7 +61,7 @@ GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
 }
 
 export function isViaCouncilOfMinisters(params) {
-    let isViaCouncilOfMinisters = params.filter.isViaCouncilOfMinisters;
+    const isViaCouncilOfMinisters = params.filter.isViaCouncilOfMinisters;
     if (isViaCouncilOfMinisters === undefined) {
       return ``;
     }
@@ -71,7 +71,7 @@ export function isViaCouncilOfMinisters(params) {
   SELECT DISTINCT
    ?publicationFlow
   WHERE {
-    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
       ?publicationFlow a pub:Publicatieaangelegenheid ;
         dossier:behandelt ?case .
       ?case a dossier:Dossier .
@@ -88,21 +88,21 @@ export function isViaCouncilOfMinisters(params) {
 };
 
 export function governmentDomains(params) {
-    let governmentDomains = params.filter.governmentDomains;
+    const governmentDomains = params.filter.governmentDomains;
     if (!governmentDomains) {
       return ``;
     }
-    let _governmentDomains = governmentDomains.map((uri) => sparqlEscapeUri(uri));
+    const governmentDomainUris = governmentDomains.map((uri) => sparqlEscapeUri(uri));
     return `
 {
   SELECT DISTINCT ?publicationFlow WHERE {
-    VALUES ?governmentDomain { ${ _governmentDomains.join('\n') } }
-    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    VALUES ?governmentDomain { ${ governmentDomainUris.join('\n') } }
+    GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
       ?publicationFlow pub:beleidsveld ?governmentDomain .
     }
-    GRAPH <http://mu.semte.ch/graphs/public> {
+    GRAPH ${sparqlEscapeUri(GRAPHS.PUBLIC)} {
       ?governmentDomain a skos:Concept ;
-        skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> .
+        skos:inScheme ${sparqlEscapeUri(CONCEPT_SCHEME_GOV_DOMAIN)} .
     }
   }
 }
@@ -110,20 +110,20 @@ export function governmentDomains(params) {
 }
 
 export function regulationType(params) {
-    let regulationTypes = params.filter.regulationType;
+    const regulationTypes = params.filter.regulationType;
     if (!regulationTypes) {
       return ``;
     }
 
-    let _regulationTypes = regulationTypes.map((uri) => sparqlEscapeUri(uri));
+    const regulationTypesUris = regulationTypes.map((uri) => sparqlEscapeUri(uri));
     return `
 {
   SELECT DISTINCT ?publicationFlow WHERE {
-    VALUES ?regulationType { ${ _regulationTypes.join('\n') } }
-    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    VALUES ?regulationType { ${ regulationTypesUris.join('\n') } }
+    GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
       ?publicationFlow pub:regelgevingType ?regulationType .
     }
-    GRAPH <http://mu.semte.ch/graphs/public> {
+    GRAPH ${sparqlEscapeUri(GRAPHS.PUBLIC)} {
       ?regulationType a ext:RegelgevingType .
     }
   }
@@ -132,21 +132,21 @@ export function regulationType(params) {
 }
 
 export function mandateePersons(params) {
-    let mandateePersons = params.filter.mandateePersons;
+    const mandateePersons = params.filter.mandateePersons;
     if (!mandateePersons) {
       return ``;
     }
 
-    let _mandateePersons = mandateePersons.map((mandatee) => sparqlEscapeUri(mandatee));
+    const mandateePersonUris = mandateePersons.map((mandatee) => sparqlEscapeUri(mandatee));
     return `
 {
   SELECT DISTINCT ?publicationFlow WHERE {
-    VALUES ?person { ${_mandateePersons.join('\n')} }
-    GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+    VALUES ?person { ${mandateePersonUris.join('\n')} }
+    GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
       ?publicationFlow a pub:Publicatieaangelegenheid ;
       ext:heeftBevoegdeVoorPublicatie ?mandatee .
     }
-    GRAPH <http://mu.semte.ch/graphs/public> {
+    GRAPH ${sparqlEscapeUri(GRAPHS.PUBLIC)} {
       ?mandatee a mandaat:Mandataris ;
         mandaat:isBestuurlijkeAliasVan ?person .
       ?person a person:Person .

--- a/queries/reports/groups.js
+++ b/queries/reports/groups.js
@@ -1,3 +1,6 @@
+import { sparqlEscapeUri} from 'mu';
+import { GRAPHS, CONCEPT_SCHEME_GOV_DOMAIN } from '../../config.js';
+
 // fragments included in SPARQL query built in index.js
 const GovernmentDomains = {
   name: 'Beleidsdomeinen',
@@ -9,15 +12,15 @@ SELECT
 WHERE {
   {
     SELECT DISTINCT COALESCE(?policyDomainLabel, "<geen>") AS ?policyDomainLabelFallback ?publicationFlow WHERE {
-      GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+      GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
         ?publicationFlow a pub:Publicatieaangelegenheid .
         OPTIONAL {
           ?publicationFlow pub:beleidsveld ?policyDomain .
-          GRAPH <http://mu.semte.ch/graphs/public> {
+          GRAPH ${sparqlEscapeUri(GRAPHS.PUBLIC)} {
             ?policyDomain
               a skos:Concept ;
               skos:prefLabel ?policyDomainLabel ;
-              skos:inScheme <http://themis.vlaanderen.be/id/concept-scheme/f4981a92-8639-4da4-b1e3-0e1371feaa81> . # policy domains
+              skos:inScheme ${sparqlEscapeUri(CONCEPT_SCHEME_GOV_DOMAIN)} . # policy domains
           }
         }
       }
@@ -38,11 +41,11 @@ SELECT
   ?publicationFlow
   COALESCE(?regulationTypeLabel, "<geen>") as ?group
 WHERE {
-  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+  GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
     ?publicationFlow a pub:Publicatieaangelegenheid .
     OPTIONAL {
       ?publicationFlow pub:regelgevingType ?regulationType .
-      GRAPH <http://mu.semte.ch/graphs/public> {
+      GRAPH ${sparqlEscapeUri(GRAPHS.PUBLIC)} {
         ?regulationType a ext:RegelgevingType ;
           skos:prefLabel ?regulationTypeLabel .
       }
@@ -62,11 +65,11 @@ SELECT
   ?publicationFlow
   (GROUP_CONCAT(DISTINCT COALESCE(?familyName, "<geen>") as ?familyNameFallback, '/' ) AS ?group) # DISTINCT some mandatees and some persons have multiple entries
 WHERE {
-  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+  GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
     ?publicationFlow a pub:Publicatieaangelegenheid .
     OPTIONAL {
       ?publicationFlow ext:heeftBevoegdeVoorPublicatie ?mandatee .
-      GRAPH <http://mu.semte.ch/graphs/public> {
+      GRAPH ${sparqlEscapeUri(GRAPHS.PUBLIC)} {
         ?mandatee a mandaat:Mandataris ;
           mandaat:isBestuurlijkeAliasVan ?person .
         ?person a person:Person ;

--- a/queries/reports/index.js
+++ b/queries/reports/index.js
@@ -1,10 +1,11 @@
-/* eslint-disable prettier/prettier */ // keep interpolated SPARQL strings clear
+import { sparqlEscapeUri} from 'mu';
 import * as Groups from './groups.js';
 import * as Filters from './filters.js';
+import { GRAPHS, STATUS_PUBLISHED } from '../../config.js';
 
 /** @see {../../doc/types.md} for documentation of query param combinations in use in the frontend */
 export function build(params) {
-  let group = Groups.get(params.group);
+  const group = Groups.get(params.group);
 
   return `
 PREFIX dct: <http://purl.org/dc/terms/>
@@ -32,12 +33,12 @@ SELECT
 WHERE {
   { ${group.subselect(params)} }
 
-  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+  GRAPH ${sparqlEscapeUri(GRAPHS.KANSELARIJ)} {
     OPTIONAL { ?publicationFlow fabio:hasPageCount ?numberOfPages . }
 
     OPTIONAL { ?publicationFlow pub:aantalUittreksels ?numberOfExtracts . }
 
-    ?publicationFlow adms:status <http://themis.vlaanderen.be/id/concept/publicatie-status/2f8dc814-bd91-4bcf-a823-baf1cdc42475> . # Gepubliceerd
+    ?publicationFlow adms:status ${sparqlEscapeUri(STATUS_PUBLISHED)} . # Gepubliceerd
   }
 
   ${Filters.publicationDate(params)}

--- a/queries/utils.js
+++ b/queries/utils.js
@@ -3,24 +3,22 @@
  * @param {Date} date
  */
 export function sparqlEscapeDateLocal(date) {
-  let year = date.getFullYear().toString().padStart(4, '0');
-  let month = (date.getMonth() + 1).toString().padStart(2, '0');
-  let day = date.getDate().toString().padStart(2, '0');
+  const year = date.getFullYear().toString().padStart(4, '0');
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
   return `"${year}-${month}-${day}"^^xsd:date`;
 }
 
 export function sparqlParseRecords(data) {
-  let vars = data.head.vars;
+  const vars = data.head.vars;
   return data.results.bindings.map((result) => {
-    let record = {};
-    for (let varKey of vars) {
-      let varInfo = result[varKey];
+    const record = {};
+    for (const varKey of vars) {
+      const varInfo = result[varKey];
       let value = result[varKey]?.value;
       if (varInfo === 'typed-literal' && varInfo !== undefined) {
-        let datatype = varInfo.datatype;
-        if (datatype === 'http://www.w3.org/2001/XMLSchema#dateTime') {
-          value = new Date(value);
-        } else if (datatype === 'http://www.w3.org/2001/XMLSchema#date') {
+        const datatype = varInfo.datatype;
+        if (datatype === 'http://www.w3.org/2001/XMLSchema#dateTime' || datatype === 'http://www.w3.org/2001/XMLSchema#date' ) {
           value = new Date(value);
         }
       }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4883

I went a bit overboard here with side tracking, I refactored all I found confusing, inconsistent (vs other services) or against good practices. I tried to limit it to job code, but splurged a little.

- refactor job statuses
- add job uri's and statuses to config
- added generic updateJobStatus to refactor methods for every possible status update (this makes the github diff hard to read)
- added schema:error in case of fail

Sidetracking:
- don't use `let` for `const` variables
- new javascript template, no more express import, use errorhandler, mu is imported differently
- extracted some constants (graphs, resource URI's) to config
- removed prettier-disable rules
- removed imported package to dasherize a string (in favor of own method)
- renamed some methods because It was getting confusing (I left Jobrunner.run and Job.run as-is because of scope)
- refactored some queries so we query/update in the method where we make the query instead of sending the query string back and then doing the query elsewhere.
- removed SUDO, should be fine to let our authorization handle it. (**Please correct me if I'm wrong**, since it seems to work fine locally. since we let the frontend create the initial job > resources decided it goes into kanselarij graph.
The virtual file and physical file metadata are also created in the kanselarij graph without needing sudo).
Since we only allow that model to be created in the kanselarij graph, this should be fine? It would only be a problem maybe if the model was allowed to write on multiple graphs. right now other profiles only have read rights)
Unsure if a delta endpoint needs sudo in this use case, where does it get the context from (assuming the context is included when the delta is sent from mu-auth)
We could make the INSERT DATA from the file sudo (just in case) or use the user's session (user is attached to job) in some way.


